### PR TITLE
ROFL.Reader cleanup

### DIFF
--- a/Rofl.Reader/Parsers/RoflParser.cs
+++ b/Rofl.Reader/Parsers/RoflParser.cs
@@ -19,26 +19,8 @@ namespace Rofl.Reader.Parsers
 
         public async Task<ReplayHeader> ReadReplayAsync(FileStream fileStream)
         {
-            if(!fileStream.CanRead)
-            {
-                throw new IOException($"{exceptionOriginName} - Stream does not support reading");
-            }
-
-            // Read and check Magic Numbers
-            byte[] magicbuffer = new byte[4];
-            try
-            {
-                await fileStream.ReadAsync(magicbuffer, 0, 4);
-                if (!magicbuffer.SequenceEqual(_magicNumbers))
-                {
-                    throw new Exception($"{exceptionOriginName} - Selected file is not in valid ROFL format");
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new IOException($"{exceptionOriginName} - Reading Magic Number: " + ex.Message);
-            }
-
+            CheckFileStreamCanRead(fileStream);
+            await CheckFileIsRoflAsync(fileStream);
 
             // Read and deserialize length fields
             byte[] lengthFieldBuffer = new byte[26];
@@ -90,6 +72,32 @@ namespace Rofl.Reader.Parsers
                 MatchMetadata = replayMatchMetadata,
                 PayloadFields = replayPayloadFields
             };
+        }
+
+        private void CheckFileStreamCanRead(FileStream fs)
+        {
+            if(!fs.CanRead)
+            {
+                throw new IOException($"{exceptionOriginName} - Stream does not support reading");
+            }
+        }
+
+        private async Task CheckFileIsRoflAsync(FileStream fs)
+        {
+            // Read and check Magic Numbers
+            byte[] magicbuffer = new byte[4];
+            try
+            {
+                await fs.ReadAsync(magicbuffer, 0, 4);
+                if (!magicbuffer.SequenceEqual(_magicNumbers))
+                {
+                    throw new Exception($"{exceptionOriginName} - Selected file is not in valid ROFL format");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"{exceptionOriginName} - Reading Magic Number: " + ex.Message);
+            }
         }
 
         private static PayloadFields ParseMatchHeader(byte[] bytedata)

--- a/Rofl.Reader/ReplayReader.cs
+++ b/Rofl.Reader/ReplayReader.cs
@@ -19,15 +19,7 @@ namespace Rofl.Reader
         /// <returns></returns>
         public async Task<ReplayFile> ReadFile(ReplayFile file)
         {
-            if (file == null || String.IsNullOrEmpty(file.Location) || String.IsNullOrEmpty(file.Name))
-            {
-                throw new ArgumentNullException($"{exceptionOriginName} - File reference is null");
-            }
-
-            if (!File.Exists(file.Location))
-            {
-                throw new FileNotFoundException($"{exceptionOriginName} - File path not found, does the file exist?");
-            }
+            CheckInput(file);
 
             IReplayParser parser = null;
             switch (file.Type)
@@ -58,6 +50,28 @@ namespace Rofl.Reader
             };
 
             return file;
+        }
+
+        private void CheckInput(ReplayFile file)
+        {
+            CheckFileReference(file);
+            CheckFileExistence(file);
+        }
+
+        private void CheckFileReference(ReplayFile file)
+        {
+            if (file == null || String.IsNullOrEmpty(file.Location) || String.IsNullOrEmpty(file.Name))
+            {
+                throw new ArgumentNullException($"{exceptionOriginName} - File reference is null");
+            }
+        }
+
+        private void CheckFileExistence(ReplayFile file)
+        {
+            if (!File.Exists(file.Location))
+            {
+                throw new FileNotFoundException($"{exceptionOriginName} - File path not found, does the file exist?");
+            }
         }
     }
 }

--- a/Rofl.Reader/ReplayReader.cs
+++ b/Rofl.Reader/ReplayReader.cs
@@ -21,15 +21,7 @@ namespace Rofl.Reader
         {
             CheckInput(file);
             file.Data = await ParseFile(file);
-
-            // Make some educated guesses
-            GameDetailsInferrer detailsInferrer = new GameDetailsInferrer();
-
-            file.Data.InferredData = new InferredData()
-            {
-                MapID = detailsInferrer.InferMap(file.Data.MatchMetadata)
-            };
-
+            file.Data.InferredData = InferData(file);
             return file;
         }
 
@@ -82,6 +74,20 @@ namespace Rofl.Reader
                     throw new Exception($"{exceptionOriginName} - Unknown replay file type");
             }
             return parser;
+        }
+
+        private InferredData InferData(ReplayFile file)
+        {
+            return new InferredData()
+            {
+                MapID = InferMap(file.Data.MatchMetadata)
+            };
+        }
+
+        private Map InferMap(MatchMetadata metadata)
+        {
+            GameDetailsInferrer detailsInferrer = new GameDetailsInferrer();
+            return detailsInferrer.InferMap(metadata)
         }
     }
 }

--- a/Rofl.Reader/ReplayReader.cs
+++ b/Rofl.Reader/ReplayReader.cs
@@ -29,17 +29,24 @@ namespace Rofl.Reader
                 throw new FileNotFoundException($"{exceptionOriginName} - File path not found, does the file exist?");
             }
 
+            IReplayParser parser = null;
             switch (file.Type)
             {
                 case REPLAYTYPES.ROFL:
-                    file.Data = await ReadROFL(file.Location);
+                    parser = new RoflParser();
                     break;
                 case REPLAYTYPES.LRF:
-                    file.Data = await ReadLRF(file.Location);
+                    parser = new LrfParser();
                     break;
                 case REPLAYTYPES.LPR:
-                    file.Data = await ReadLPR(file.Location);
+                    parser = new LprParser();
                     break;
+                default:
+                    throw new Exception($"{exceptionOriginName} - Unknown replay file type");
+            }
+
+            using (FileStream fs = new FileStream(file.Location, FileMode.Open)) {
+                file.Data = await parser.ReadReplayAsync(fs);
             }
 
             // Make some educated guesses
@@ -51,36 +58,6 @@ namespace Rofl.Reader
             };
 
             return file;
-        }
-
-        public async Task<ReplayHeader> ReadROFL(string filePath)
-        {
-            var roflParser = new RoflParser();
-
-            using (FileStream fileStream = new FileStream(filePath, FileMode.Open))
-            {
-                return await roflParser.ReadReplayAsync(fileStream);
-            }
-        }
-
-        public async Task<ReplayHeader> ReadLRF(string filePath)
-        {
-            var lrfParser = new LrfParser();
-
-            using (FileStream fileStream = new FileStream(filePath, FileMode.Open))
-            {
-                return await lrfParser.ReadReplayAsync(fileStream);
-            }
-        }
-
-        public async Task<ReplayHeader> ReadLPR(string filePath)
-        {
-            var lprParser = new LprParser();
-
-            using (FileStream fileStream = new FileStream(filePath, FileMode.Open))
-            {
-                return await lprParser.ReadReplayAsync(fileStream);
-            }
         }
     }
 }

--- a/Rofl.Reader/Utilities/GameDetailsInferrer.cs
+++ b/Rofl.Reader/Utilities/GameDetailsInferrer.cs
@@ -7,37 +7,48 @@ namespace Rofl.Reader.Utilities
     {
         public Map InferMap(MatchMetadata matchMetadata)
         {
-            // Check if any players have killed jungle creeps, Rules out HowlingAbyss
-            var JungleCheck = (from player in matchMetadata.AllPlayers
-                               where int.Parse(player["NEUTRAL_MINIONS_KILLED"]) > 0
-                               select player);
-
-            // Check if any players have placed wards, Rules out TwistedTreeline and HowlingAbyss
-            var WardCheck = (from player in matchMetadata.AllPlayers
-                             where int.Parse(player["WARD_PLACED"]) > 0
-                             select player);
-
-            // Double check between TwistedTreeline and SummonersRift
-            var DragonCheck = (from player in matchMetadata.AllPlayers
-                               where int.Parse(player["DRAGON_KILLS"]) > 0
-                               select player);
-
-            if (JungleCheck.Count() > 0)
+            Map inferredMap;
+            if (!HasJungle(matchMetadata))
             {
-                if (WardCheck.Count() == 0 && DragonCheck.Count() == 0)
-                {
-                    return Map.TwistedTreeline;
-                }
-                else
-                {
-                    return Map.SummonersRift;
-                }
-
-            }
-            else
+                inferredMap = Map.HowlingAbyss;
+            } else if (!HasWards(matchMetadata) && !HasDragon(matchMetadata))
             {
-                return Map.HowlingAbyss;
+                inferredMap = Map.TwistedTreeline;
+            } else
+            {
+                inferredMap = Map.SummonersRift;
             }
+            return inferredMap;
+        }
+
+        // check if any players have killed jungle creeps, rules out HowlingAbyss
+        private bool HasJungle(MatchMetadata metadata)
+        {
+            return (
+                from player in metadata.AllPlayers
+                where int.Parse(player["NEUTRAL_MINIONS_KILLED"]) > 0
+                select player
+            ).Count() > 0;
+        } 
+
+        // check if any players have placed wards, rules out TwistedTreeline and HowlingAbyss
+        private bool HasWards(MatchMetadata metadata)
+        {
+            return (
+                from player in metadata.AllPlayers
+                where int.Parse(player["WARDS_PLACED"]) > 0
+                select player
+            ).Count() > 0;
+        }
+
+        // check if any player has killed a dragon, SummonersRift only
+        private bool HasDragon(MatchMetadata metadata)
+        {
+            return (
+                from player in metadata.AllPlayers
+                where int.Parse(player["DRAGON_KILLS"]) > 0
+                select player
+            ).Count() > 0;
         }
     }
 }

--- a/Rofl.Reader/Utilities/ParserHelpers.cs
+++ b/Rofl.Reader/Utilities/ParserHelpers.cs
@@ -16,7 +16,7 @@ namespace Rofl.Reader.Utilities
             }
             catch (Exception ex)
             {
-                throw new IOException(logLocation + " - " + ex.Message);
+                throw new IOException($"{logLocation} - {ex.Message}");
             }
         }
 
@@ -29,7 +29,7 @@ namespace Rofl.Reader.Utilities
             }
             catch (Exception ex)
             {
-                throw new IOException(logLocation + " - " + ex.Message);
+                throw new IOException($"{logLocation} - {ex.Message}");
             }
         }
     }

--- a/Rofl.Reader/Utilities/ParserHelpers.cs
+++ b/Rofl.Reader/Utilities/ParserHelpers.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Rofl.Reader.Utilities


### PR DESCRIPTION
Cleaned up code of the ROFL.Reader for better readability.

Changes:
- `RoflParser.cs`:
  - Split up the "god method" into several smaller bits of code
  - Generalized the reading of the ReplayHeader segments

- `ReplayReader.cs`:
  - Split up method into smaller code segments
  - Made use of the `IReplayParser` in order to reduce redundancy

- `GameDetailsInferrer.cs`:
  - Split up method into smaller code segments
  - Changed the `if...else` structure of the inferrer in order to reduce indentation (not 100% proof, didn't have time to test it thoroughly)

- `ParserHelper.cs`:
  - Removed unused imports
  - Used string interpolation for consistency.